### PR TITLE
UF-XYZ - SMB trimming

### DIFF
--- a/src/main/java/se/sundsvall/invoicesender/integration/raindance/RaindanceIntegrationProperties.java
+++ b/src/main/java/se/sundsvall/invoicesender/integration/raindance/RaindanceIntegrationProperties.java
@@ -42,6 +42,8 @@ record RaindanceIntegrationProperties(
         var jcifsProperties = new Properties();
         jcifsProperties.setProperty("jcifs.smb.client.connTimeout", Long.toString(connectTimeout().toMillis()));
         jcifsProperties.setProperty("jcifs.smb.client.responseTimeout", Long.toString(responseTimeout().toMillis()));
+        jcifsProperties.setProperty("jcifs.smb.client.minVersion", "SMB300");
+        jcifsProperties.setProperty("jcifs.smb.client.maxVersion", "SMB311");
         return jcifsProperties;
     }
 }


### PR DESCRIPTION
Forces SMB >= 3.0 for the Raindance integation, and attempts to explicitly close and SMB resources to avoid warnings on not releasing/closing tree and file handles.