### PR TITLE
UF-10105 - Raindance metadata sanity check

### DIFF
--- a/src/main/java/se/sundsvall/invoicesender/integration/db/DbIntegration.java
+++ b/src/main/java/se/sundsvall/invoicesender/integration/db/DbIntegration.java
@@ -1,8 +1,8 @@
 package se.sundsvall.invoicesender.integration.db;
 
 import static java.util.Optional.ofNullable;
+import static se.sundsvall.invoicesender.model.Item.ITEM_IS_AN_INVOICE;
 import static se.sundsvall.invoicesender.model.Item.ITEM_IS_IGNORED;
-import static se.sundsvall.invoicesender.model.Item.ITEM_IS_INVOICE;
 import static se.sundsvall.invoicesender.model.Item.ITEM_IS_PROCESSABLE;
 import static se.sundsvall.invoicesender.model.Item.ITEM_IS_SENT;
 
@@ -48,7 +48,7 @@ public class DbIntegration {
 			.withStartedAt(batch.getStartedAt())
 			.withCompletedAt(batch.getCompletedAt())
 			.withItems(items.stream()
-				.filter(ITEM_IS_INVOICE)
+				.filter(ITEM_IS_AN_INVOICE)
 				.map(item -> new ItemEntity()
 					.withStatus(item.getStatus())
 					.withFilename(item.getFilename()))

--- a/src/main/java/se/sundsvall/invoicesender/model/Item.java
+++ b/src/main/java/se/sundsvall/invoicesender/model/Item.java
@@ -1,6 +1,8 @@
 package se.sundsvall.invoicesender.model;
 
+import static java.util.function.Predicate.not;
 import static se.sundsvall.invoicesender.model.ItemStatus.IGNORED;
+import static se.sundsvall.invoicesender.model.ItemStatus.METADATA_INCOMPLETE;
 import static se.sundsvall.invoicesender.model.ItemStatus.RECIPIENT_LEGAL_ID_FOUND;
 import static se.sundsvall.invoicesender.model.ItemStatus.RECIPIENT_PARTY_ID_FOUND;
 import static se.sundsvall.invoicesender.model.ItemStatus.SENT;
@@ -10,10 +12,11 @@ import java.util.function.Predicate;
 
 public class Item {
 
-    public static final Predicate<Item> ITEM_IS_A_PDF = item -> item.getFilename().endsWith(".pdf");
-    public static final Predicate<Item> ITEM_IS_INVOICE = item -> item.getType() == INVOICE;
-    public static final Predicate<Item> ITEM_IS_PROCESSABLE = ITEM_IS_INVOICE.and(item -> item.getStatus() != IGNORED);
-    public static final Predicate<Item> ITEM_IS_IGNORED = ITEM_IS_INVOICE.and(item -> item.getStatus() == IGNORED);
+    public static final Predicate<Item> ITEM_IS_A_PDF = item -> item.getFilename().toLowerCase().endsWith(".pdf");
+    public static final Predicate<Item> ITEM_IS_AN_INVOICE = ITEM_IS_A_PDF.and(item -> item.getType() == INVOICE);
+    public static final Predicate<Item> ITEM_IS_IGNORED = item -> item.getStatus() == IGNORED;
+    public static final Predicate<Item> ITEM_LACKS_METADATA = item -> item.getStatus() == METADATA_INCOMPLETE;
+    public static final Predicate<Item> ITEM_IS_PROCESSABLE = ITEM_IS_AN_INVOICE.and(not(ITEM_IS_IGNORED)).and(not(ITEM_LACKS_METADATA));
     public static final Predicate<Item> ITEM_HAS_LEGAL_ID = item -> item.getStatus() == RECIPIENT_LEGAL_ID_FOUND;
     public static final Predicate<Item> ITEM_HAS_PARTY_ID = item -> item.getStatus() == RECIPIENT_PARTY_ID_FOUND;
     public static final Predicate<Item> ITEM_IS_SENT = item -> item.getStatus() == SENT;

--- a/src/main/java/se/sundsvall/invoicesender/model/ItemStatus.java
+++ b/src/main/java/se/sundsvall/invoicesender/model/ItemStatus.java
@@ -5,6 +5,8 @@ public enum ItemStatus {
     UNHANDLED,
     /** Indicates that an invoice should be ignored */
     IGNORED,
+    /** Indicates that an invoice lacks required metadata */
+    METADATA_INCOMPLETE,
     /** Indicates that a valid legal id was found in the filename */
     RECIPIENT_LEGAL_ID_FOUND,
     /** Indicates that no valid legal id was found in the filename */

--- a/src/test/java/se/sundsvall/invoicesender/integration/db/DbIntegrationTests.java
+++ b/src/test/java/se/sundsvall/invoicesender/integration/db/DbIntegrationTests.java
@@ -69,14 +69,13 @@ class DbIntegrationTests {
 			.withBasename("someBasename")
 			.withItems(List.of(
 				new Item("something.xml").withType(OTHER).withStatus(UNHANDLED),
-				new Item("file1").withType(INVOICE).withStatus(SENT),
-				new Item("file2").withType(INVOICE).withStatus(SENT),
-				new Item("file3").withType(INVOICE).withStatus(IGNORED),
-				new Item("file4").withType(INVOICE).withStatus(NOT_SENT),
-				new Item("file5").withType(INVOICE).withStatus(NOT_SENT)
+				new Item("file1.pdf").withType(INVOICE).withStatus(SENT),
+				new Item("file2.pdf").withType(INVOICE).withStatus(SENT),
+				new Item("file3.pdf").withType(INVOICE).withStatus(IGNORED),
+				new Item("file4.pdf").withType(INVOICE).withStatus(NOT_SENT),
+				new Item("file5.pdf").withType(INVOICE).withStatus(NOT_SENT)
 			));
 		batch.setCompleted();
-
 
 		dbIntegration.storeBatch(batch, municipalityId);
 

--- a/src/test/java/se/sundsvall/invoicesender/model/ItemPredicateTests.java
+++ b/src/test/java/se/sundsvall/invoicesender/model/ItemPredicateTests.java
@@ -1,0 +1,101 @@
+package se.sundsvall.invoicesender.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.sundsvall.invoicesender.model.Item.ITEM_HAS_LEGAL_ID;
+import static se.sundsvall.invoicesender.model.Item.ITEM_HAS_PARTY_ID;
+import static se.sundsvall.invoicesender.model.Item.ITEM_IS_AN_INVOICE;
+import static se.sundsvall.invoicesender.model.Item.ITEM_IS_A_PDF;
+import static se.sundsvall.invoicesender.model.Item.ITEM_IS_IGNORED;
+import static se.sundsvall.invoicesender.model.Item.ITEM_IS_PROCESSABLE;
+import static se.sundsvall.invoicesender.model.Item.ITEM_IS_SENT;
+import static se.sundsvall.invoicesender.model.Item.ITEM_LACKS_METADATA;
+import static se.sundsvall.invoicesender.model.ItemStatus.IGNORED;
+import static se.sundsvall.invoicesender.model.ItemStatus.METADATA_INCOMPLETE;
+import static se.sundsvall.invoicesender.model.ItemStatus.RECIPIENT_LEGAL_ID_FOUND;
+import static se.sundsvall.invoicesender.model.ItemStatus.RECIPIENT_PARTY_ID_FOUND;
+import static se.sundsvall.invoicesender.model.ItemStatus.SENT;
+import static se.sundsvall.invoicesender.model.ItemStatus.UNHANDLED;
+import static se.sundsvall.invoicesender.model.ItemType.INVOICE;
+import static se.sundsvall.invoicesender.model.ItemType.OTHER;
+
+import org.junit.jupiter.api.Test;
+
+class ItemPredicateTests {
+
+    private static final String DUMMY_DOT_PDF = "dummy.pdf";
+    private static final String DUMMY_DOT_DOCX = "dummy.docx";
+
+    @Test
+    void test_ITEM_IS_A_PDF() {
+        var pdfItem = new Item(DUMMY_DOT_PDF);
+        var nonPdfItem = new Item(DUMMY_DOT_DOCX);
+
+        assertThat(ITEM_IS_A_PDF.test(pdfItem)).isTrue();
+        assertThat(ITEM_IS_A_PDF.test(nonPdfItem)).isFalse();
+    }
+
+    @Test
+    void test_ITEM_IS_AN_INVOICE() {
+        var invoiceItem = new Item(DUMMY_DOT_PDF).withType(INVOICE);
+        var nonInvoiceItem = new Item(DUMMY_DOT_DOCX).withType(OTHER);
+
+        assertThat(ITEM_IS_AN_INVOICE.test(invoiceItem)).isTrue();
+        assertThat(ITEM_IS_AN_INVOICE.test(nonInvoiceItem)).isFalse();
+    }
+
+    @Test
+    void test_ITEM_IS_IGNORED() {
+        var item = new Item(DUMMY_DOT_PDF).withStatus(UNHANDLED);
+        var ignoredItem = new Item(DUMMY_DOT_DOCX).withStatus(IGNORED);
+
+        assertThat(ITEM_IS_IGNORED.test(item)).isFalse();
+        assertThat(ITEM_IS_IGNORED.test(ignoredItem)).isTrue();
+    }
+
+    @Test
+    void test_ITEM_LACKS_METADATA() {
+        var itemWithMetadata = new Item(DUMMY_DOT_PDF).withStatus(UNHANDLED);
+        var itemWithoutMetadata = new Item(DUMMY_DOT_DOCX).withStatus(METADATA_INCOMPLETE);
+
+        assertThat(ITEM_LACKS_METADATA.test(itemWithMetadata)).isFalse();
+        assertThat(ITEM_LACKS_METADATA.test(itemWithoutMetadata)).isTrue();
+    }
+
+    @Test
+    void test_ITEM_IS_PROCESSABLE() {
+        var processableInvoiceItem = new Item(DUMMY_DOT_PDF).withType(INVOICE).withStatus(UNHANDLED);
+        var ignoredItem = new Item(DUMMY_DOT_DOCX).withStatus(IGNORED);
+        var itemWithoutMetadata = new Item(DUMMY_DOT_DOCX).withStatus(METADATA_INCOMPLETE);
+
+        assertThat(ITEM_IS_PROCESSABLE.test(processableInvoiceItem)).isTrue();
+        assertThat(ITEM_IS_PROCESSABLE.test(ignoredItem)).isFalse();
+        assertThat(ITEM_IS_PROCESSABLE.test(itemWithoutMetadata)).isFalse();
+    }
+
+    @Test
+    void test_ITEM_HAS_LEGAL_ID() {
+        var item1 = new Item(DUMMY_DOT_PDF).withStatus(RECIPIENT_LEGAL_ID_FOUND);
+        var item2 = new Item(DUMMY_DOT_PDF).withStatus(UNHANDLED);
+
+        assertThat(ITEM_HAS_LEGAL_ID.test(item1)).isTrue();
+        assertThat(ITEM_HAS_LEGAL_ID.test(item2)).isFalse();
+    }
+
+    @Test
+    void test_ITEM_HAS_PARTY_ID() {
+        var item1 = new Item(DUMMY_DOT_PDF).withStatus(RECIPIENT_PARTY_ID_FOUND);
+        var item2 = new Item(DUMMY_DOT_PDF).withStatus(UNHANDLED);
+
+        assertThat(ITEM_HAS_PARTY_ID.test(item1)).isTrue();
+        assertThat(ITEM_HAS_PARTY_ID.test(item2)).isFalse();
+    }
+
+    @Test
+    void test_ITEM_IS_SENT() {
+        var item1 = new Item(DUMMY_DOT_PDF).withStatus(SENT);
+        var item2 = new Item(DUMMY_DOT_PDF).withStatus(UNHANDLED);
+
+        assertThat(ITEM_IS_SENT.test(item1)).isTrue();
+        assertThat(ITEM_IS_SENT.test(item2)).isFalse();
+    }
+}

--- a/src/test/java/se/sundsvall/invoicesender/model/ItemTests.java
+++ b/src/test/java/se/sundsvall/invoicesender/model/ItemTests.java
@@ -40,7 +40,6 @@ class ItemTests {
         });
     }
 
-
     @Test
     void testWithersAndGetters() {
         var item = new Item()

--- a/src/test/java/se/sundsvall/invoicesender/service/InvoiceProcessorTests.java
+++ b/src/test/java/se/sundsvall/invoicesender/service/InvoiceProcessorTests.java
@@ -223,10 +223,10 @@ class InvoiceProcessorTests {
 	void getProcessableInvoiceItems() {
 		final var batch = new Batch()
 			.withItems(List.of(
-				new Item("file1").withType(OTHER),
-				new Item("file2").withType(INVOICE),
-				new Item("file3").withType(INVOICE),
-				new Item("file4").withType(INVOICE).withStatus(IGNORED)
+				new Item("file1.png").withType(OTHER),
+				new Item("file2.pdf").withType(INVOICE),
+				new Item("file3.pdf").withType(INVOICE),
+				new Item("file4.pdf").withType(INVOICE).withStatus(IGNORED)
 			));
 
 		final var result = invoiceProcessor.getProcessableInvoiceItems(batch);
@@ -238,11 +238,11 @@ class InvoiceProcessorTests {
 	void getSentInvoiceItems() {
 		final var batch = new Batch()
 			.withItems(List.of(
-				new Item("file1").withType(OTHER),
-				new Item("file2").withType(INVOICE).withStatus(SENT),
-				new Item("file3").withType(INVOICE).withStatus(SENT),
-				new Item("file4").withType(INVOICE).withStatus(IGNORED),
-				new Item("file5").withType(INVOICE).withStatus(NOT_SENT)
+				new Item("file1.jpg").withType(OTHER),
+				new Item("file2.pdf").withType(INVOICE).withStatus(SENT),
+				new Item("file3.pdf").withType(INVOICE).withStatus(SENT),
+				new Item("file4.pdf").withType(INVOICE).withStatus(IGNORED),
+				new Item("file5.pdf").withType(INVOICE).withStatus(NOT_SENT)
 			));
 
 		final var result = invoiceProcessor.getSentInvoiceItems(batch);
@@ -254,11 +254,11 @@ class InvoiceProcessorTests {
 	void getInvoiceItemsWithPartyIdSet() {
 		final var batch = new Batch()
 			.withItems(List.of(
-				new Item("file1").withType(OTHER),
-				new Item("file2").withType(INVOICE).withStatus(RECIPIENT_PARTY_ID_FOUND),
-				new Item("file3").withType(INVOICE).withStatus(RECIPIENT_PARTY_ID_FOUND),
-				new Item("file4").withType(INVOICE).withStatus(RECIPIENT_PARTY_ID_NOT_FOUND),
-				new Item("file5").withType(INVOICE)
+				new Item("file1.txt").withType(OTHER),
+				new Item("file2.pdf").withType(INVOICE).withStatus(RECIPIENT_PARTY_ID_FOUND),
+				new Item("file3.pdf").withType(INVOICE).withStatus(RECIPIENT_PARTY_ID_FOUND),
+				new Item("file4.pdf").withType(INVOICE).withStatus(RECIPIENT_PARTY_ID_NOT_FOUND),
+				new Item("file5.pdf").withType(INVOICE)
 			));
 
 		final var result = invoiceProcessor.getInvoiceItemsWithPartyIdSet(batch);
@@ -270,11 +270,11 @@ class InvoiceProcessorTests {
 	void getInvoiceItemsWithLegalIdSet() {
 		final var batch = new Batch()
 			.withItems(List.of(
-				new Item("file1").withType(OTHER),
-				new Item("file2").withType(INVOICE).withStatus(RECIPIENT_LEGAL_ID_FOUND),
-				new Item("file3").withType(INVOICE).withStatus(RECIPIENT_LEGAL_ID_NOT_FOUND_OR_INVALID),
-				new Item("file4").withType(INVOICE).withStatus(RECIPIENT_LEGAL_ID_NOT_FOUND_OR_INVALID),
-				new Item("file5").withType(INVOICE)
+				new Item("file1.docx").withType(OTHER),
+				new Item("file2.pdf").withType(INVOICE).withStatus(RECIPIENT_LEGAL_ID_FOUND),
+				new Item("file3.pdf").withType(INVOICE).withStatus(RECIPIENT_LEGAL_ID_NOT_FOUND_OR_INVALID),
+				new Item("file4.pdf").withType(INVOICE).withStatus(RECIPIENT_LEGAL_ID_NOT_FOUND_OR_INVALID),
+				new Item("file5.pdf").withType(INVOICE)
 			));
 
 		final var result = invoiceProcessor.getInvoiceItemsWithLegalIdSet(batch);


### PR DESCRIPTION
Adds a sanity check on the Raindance metadata, and a new item status, to be able to short-circuit processing when the metadata is incomplete instead of sending invalid requests to Kivra.