### PR TITLE
UF-XYZ Stop Dependabot from updating Jsoup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     target-branch: "main"
     schedule:
       interval: "weekly"
+ignore:
+  # Version 1.20.1 is breaking the expected format of ArchiveIndex.xml for Stråkfors. 
+  # Temporarily stopping any Jsoup updates before a more sustainable fix is implemented.
+  - dependency-name: "org.jsoup:jsoup"


### PR DESCRIPTION
* Temporary fix to stop Dependabot from breaking the format of ArchiveIndex.xml that Strålfors is expecting. 

Jsoup changelog:  _"To better follow the HTML5 spec and current browsers, the HTML parser no longer allows self-closing tags (<foo />) to close HTML elements by default. "_

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
